### PR TITLE
Make the GitHub Token Lookup more flexible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,7 @@ jobs:
         shell: bash
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
-      - env:
-          GITHUB_USER: ${{ secrets.GH_USER }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REMOTE_CACHE_USER: ${{ secrets.GH_USER }}
-          GITHUB_REMOTE_CACHE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
+      - shell: bash
         run: |
           rm -rf ~/.ivy2/cache/io.github.er1c
           rm -rf ~/.ivy2/local/io.github.er1c
@@ -68,12 +63,14 @@ jobs:
           echo "
           realm = GitHub API Realm
           host = api.github.com
-          user = $GITHUB_USER
-          password = $GITHUB_TOKEN
+          user = ${{ secrets.GH_USER }}
+          password = ${{ secrets.GITHUB_TOKEN }}
           " >> ~/.github/.credentials
 
       
-      - shell: bash
+      - env:
+          GITHUB_TOKEN_FOR_ENV_TEST: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: sbt ++${{ matrix.scala }} test scripted
 
       - name: Compress target directories

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.bsp/
+.idea/

--- a/README.md
+++ b/README.md
@@ -10,24 +10,14 @@ Forking/refactoring [`sbt-bintray`](https://github.com/sbt/sbt-bintray) for GitH
 
 See [remote caching](REMOTE_CACHE.md) for information about sbt-github-remote-cache.
 
-## Consuming or publishing?
-
-```scala
-resolvers +=  "sbt-github-releases" at "https://maven.pkg.github.com/er1c/sbt-github"
-credentials += Credentials("GitHub Package Registry", "maven.pkg.github.com", "<github-user>", "<GITHUB_TOKEN>")
-```
-
-If you want to _publish_ to GitHub, read on.
-
 ## Install
 
 ### What you need
 
-
 Add the following to your sbt `project/plugins.sbt` file:
 
 ```scala
-addSbtPlugin("io.github.er1c" % "sbt-github" % "0.2.0")
+addSbtPlugin("io.github.er1c" % "sbt-github" % "0.3.0")
 ```
 
 ## Usage
@@ -36,6 +26,14 @@ Note that when specifying `sbt-github` settings in `project/*.scala` files (as o
 
 ```scala
 import github.GitHubPluginKeys._
+```
+
+### Reading Packages
+
+```scala
+resolvers += "github-packages-tests" at "https://maven.pkg.github.com/er1c/github-packages-tests"
+githubTokenSource := TokenSource.Environment("GITHUB_TOKEN") // optional since this is in the default chain
+libraryDependencies += "com.example" % "java-project-example" % "0.1.0"
 ```
 
 ### GitHub User
@@ -74,6 +72,17 @@ At any time you can check who you will be authenticated as with the `githubWhoam
 
 To publish, you need to provide github credentials (user name and API key). There are three ways to set them up: credential file, properties, and environment variables.
 
+The default chain is:
+
+```scala
+    githubTokenSource :=
+      TokenSource.Property("github.token") ||
+        TokenSource.Environment("GITHUB_TOKEN") ||
+        TokenSource.GitConfig("github.token"),
+```
+
+With a fall back to the `~/.github/.credentials` file.
+
 1. Credentials file
 
 sbt-github will look for a credentials file under `~/.github/.credentials` used to authenticate publishing requests to github.
@@ -95,11 +104,26 @@ Note you will need to `reload` your project afterwards which will reset your `pu
 
 You can pass the user and pass as JVM properties when starting sbt:
 
-    sbt -Dgithub.user=yourgithubUser -Dgithub.pass=yourgithubPass
+    sbt -Dgithub.token=yourgithubtoken
     
 3. Environment variables
 
-sbt-github will look for github user and pass in the environment variables `github_USER` and  `github_PASS`.
+sbt-github will look for github token in the environment variable `GITHUB_TOKEN`.
+
+3. Git Config
+
+sbt-github will look in git config in the path `github.token`.
+
+4. Alternatively, you can also specify the credentials in your `~/.sbt/1.0/credentials.sbt`, and use file:
+
+```scala
+credentials +=
+  Credentials(
+    "GitHub Package Registry",
+    "maven.pkg.github.com",
+    "USERNAME",
+    "TOKEN")
+```
 
 #### github organization
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,21 +24,21 @@ ThisBuild / githubWorkflowBuild := Seq(
            |echo "
            |realm = GitHub API Realm
            |host = api.github.com
-           |user = $GITHUB_USER
-           |password = $GITHUB_TOKEN
+           |user = ${{ secrets.GH_USER }}
+           |password = ${{ secrets.GITHUB_TOKEN }}
            |" >> ~/.github/.credentials
            |""".stripMargin)
     },
-    env = Map(
-      "GITHUB_USER" -> "${{ secrets.GH_USER }}",
-      "GITHUB_TOKEN" -> "${{ secrets.GITHUB_TOKEN }}",
-      "GITHUB_REMOTE_CACHE_USER" -> "${{ secrets.GH_USER }}",
-      "GITHUB_REMOTE_CACHE_TOKEN" -> "${{ secrets.GITHUB_TOKEN }}"
-    )
+//    env = Map(
+//      "GITHUB_USER" -> "${{ secrets.GH_USER }}",
+//      "GITHUB_TOKEN" -> "${{ secrets.GITHUB_TOKEN }}"
+//    )
   ),
   WorkflowStep.Sbt(
     commands = List("test", "scripted"),
-    env = Map.empty
+    env = Map(
+      "GITHUB_TOKEN_FOR_ENV_TEST" -> "${{ secrets.GITHUB_TOKEN }}",
+    )
   )
 )
 

--- a/core/src/main/scala/github/GitHubCredentialContext.scala
+++ b/core/src/main/scala/github/GitHubCredentialContext.scala
@@ -7,28 +7,5 @@ import java.io.File
  */
 case class GitHubCredentialContext(
   credsFile: File,
-  userProp: String,
-  tokenProp: String,
-  userEnv: String,
-  tokenEnv: String
+  tokenSource: TokenSource
 )
-
-object GitHubCredentialContext {
-  def apply(credsFile: File): GitHubCredentialContext =
-    GitHubCredentialContext(
-      credsFile,
-      "github.user",
-      "github.token",
-      "GITHUB_USER",
-      "GITHUB_TOKEN"
-    )
-
-  def remoteCache(credsFile: File): GitHubCredentialContext =
-    GitHubCredentialContext(
-      credsFile,
-      "github.remote.cache.user",
-      "github.remote.cache.token",
-      "GITHUB_REMOTE_CACHE_USER",
-      "GITHUB_REMOTE_CACHE_TOKEN"
-    )
-}

--- a/core/src/main/scala/github/GitHubCredentials.scala
+++ b/core/src/main/scala/github/GitHubCredentials.scala
@@ -4,6 +4,7 @@ import sbt._
 import java.io.File
 
 case class GitHubCredentials(user: String, token: String) {
+  def this(token: String) = this("_", token) // GitHub doesn't care about user
   override def toString = s"GitHubCredentials($user, ${"x"*token.size})"
 }
 

--- a/core/src/main/scala/github/TokenSource.scala
+++ b/core/src/main/scala/github/TokenSource.scala
@@ -1,0 +1,49 @@
+/*
+ * Adapted from Copyright 2019 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package github
+
+import scala.sys.process._
+import scala.util.Try
+
+sealed trait TokenSource extends Product with Serializable {
+  def ||(that: TokenSource): TokenSource =
+    TokenSource.Or(this, that)
+}
+
+object TokenSource {
+  final case class Environment(variable: String) extends TokenSource
+  final case class Property(key: String) extends TokenSource
+  final case class GitConfig(key: String) extends TokenSource
+  final case class Or(primary: TokenSource, secondary: TokenSource) extends TokenSource
+
+  def resolveTokenSource(tokenSource: TokenSource): Option[String] = {
+    tokenSource match {
+      case TokenSource.Or(primary, secondary) =>
+        resolveTokenSource(primary).orElse(
+          resolveTokenSource(secondary))
+
+      case TokenSource.Environment(variable) =>
+        sys.env.get(variable)
+
+      case TokenSource.Property(key) =>
+        sys.props.get(key)
+
+      case TokenSource.GitConfig(key) =>
+        Try(s"git config $key".!!).map(_.trim).toOption
+    }
+  }
+}

--- a/sbt-github-remote-cache/src/main/scala/github/GitHubRemoteCacheKeys.scala
+++ b/sbt-github-remote-cache/src/main/scala/github/GitHubRemoteCacheKeys.scala
@@ -7,6 +7,7 @@ trait GitHubRemoteCacheKeys {
   val githubRemoteCache = taskKey[String]("sbt-github-remote-cache is an interface for the github package service")
 
   val githubRemoteCacheCredentialsFile = settingKey[File]("File containing github api credentials")
+  val githubRemoteCacheTokenSource = settingKey[TokenSource]("Where to get the API token used in publication (defaults to github.token property, then GITHUB_TOKEN environment, then github.token in the git config)")
 
   val githubRemoteCacheOwner = settingKey[String]("GitHub user or organization name to push to")
   val githubRemoteCacheOwnerType = settingKey[GitHubOwnerType]("GitHub owner type (GitHubOwnerType.User or GitHubOwnerType.Org), default GitHubOwnerType.User.")

--- a/sbt-github/src/main/scala/github/GitHubKeys.scala
+++ b/sbt-github/src/main/scala/github/GitHubKeys.scala
@@ -3,7 +3,7 @@ package github
 import sbt._
 
 trait GitHubKeys {
-  val github = taskKey[String]("sbt-github is an interface for the github package service")
+  val sbtgithub = taskKey[String]("sbt-github is an interface for the github package service")
 
   val githubOwner = settingKey[String]("GitHub user or organization name to publish to.")
   val githubRepository = settingKey[String]("GitHub repository to publish to.")
@@ -12,6 +12,7 @@ trait GitHubKeys {
 
   val githubResolverName = settingKey[String]("GitHub resolver name, default github-{githubOwner}-{githubRepository}.")
   val githubCredentialsFile = settingKey[File]("File containing github api credentials")
+  val githubTokenSource = settingKey[TokenSource]("Where to get the API token used in publication (defaults to github.token property, then GITHUB_TOKEN environment, then github.token in the git config)")
   val githubPackageVersions = taskKey[Seq[String]]("List github versions for the current package")
 
   val githubChangeCredentials = taskKey[Unit]("Change your current github credentials")

--- a/sbt-github/src/sbt-test/sbt-github/default-credentials/build.sbt
+++ b/sbt-github/src/sbt-test/sbt-github/default-credentials/build.sbt
@@ -1,0 +1,16 @@
+val check = taskKey[Unit]("check")
+
+
+resolvers += "github-packages-tests" at "https://maven.pkg.github.com/er1c/github-packages-tests"
+name := "default-credentials"
+libraryDependencies += "com.example" % "java-project-example" % "0.1.0"
+check := (Def.task {
+  val creds = credentials.value
+  assert(creds.nonEmpty, "credentials were empty")
+  creds.foreach{
+    case cred: DirectCredentials =>
+      assert(cred.host == "maven.pkg.github.com", "Didn't get maven.pkg.github.com credentials")
+    case cred: FileCredentials => ()
+  }
+  ()
+}).value

--- a/sbt-github/src/sbt-test/sbt-github/default-credentials/project/plugins.sbt
+++ b/sbt-github/src/sbt-test/sbt-github/default-credentials/project/plugins.sbt
@@ -1,0 +1,9 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("io.github.er1c" % "sbt-github" % pluginVersion)
+}
+
+//resolvers += "github-packages-tests" at "https://maven.pkg.github.com/er1c/github-packages-tests"

--- a/sbt-github/src/sbt-test/sbt-github/default-credentials/test
+++ b/sbt-github/src/sbt-test/sbt-github/default-credentials/test
@@ -1,0 +1,3 @@
+> check
+> update
+> compile

--- a/sbt-github/src/sbt-test/sbt-github/github-resolver-style/build.sbt
+++ b/sbt-github/src/sbt-test/sbt-github/github-resolver-style/build.sbt
@@ -12,7 +12,7 @@ lazy val mavenStyle = (project in file("maven-style"))
     githubOwner := "tinyrick",
     githubRepository := "evilmorty",
     TaskKey[Unit]("check") := {
-      assert((github / resolvers).value.filter(_.name.equals("github-tinyrick-evilmorty")).head.isInstanceOf[MavenRepository],
+      assert((sbtgithub / resolvers).value.filter(_.name.equals("github-tinyrick-evilmorty")).head.isInstanceOf[MavenRepository],
         "A maven style project should have a maven repository as it default resolver"
       )
     }

--- a/sbt-github/src/sbt-test/sbt-github/package-versions/build.sbt
+++ b/sbt-github/src/sbt-test/sbt-github/package-versions/build.sbt
@@ -2,7 +2,7 @@ import sbt.util
 
 import _root_.github.InternalGitHubKeys._
 
-logLevel := util.Level.Debug
+//logLevel := util.Level.Debug
 
 lazy val aggregatorIDs = Seq(
   "javaProjectExample",

--- a/sbt-github/src/sbt-test/sbt-github/token-source/build.sbt
+++ b/sbt-github/src/sbt-test/sbt-github/token-source/build.sbt
@@ -1,0 +1,4 @@
+resolvers += "github-packages-tests" at "https://maven.pkg.github.com/er1c/github-packages-tests"
+githubTokenSource := TokenSource.Environment("GITHUB_TOKEN_FOR_ENV_TEST")
+name := "default-credentials"
+libraryDependencies += "com.example" % "java-project-example" % "0.1.0"

--- a/sbt-github/src/sbt-test/sbt-github/token-source/project/plugins.sbt
+++ b/sbt-github/src/sbt-test/sbt-github/token-source/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("io.github.er1c" % "sbt-github" % pluginVersion)
+}

--- a/sbt-github/src/sbt-test/sbt-github/token-source/test
+++ b/sbt-github/src/sbt-test/sbt-github/token-source/test
@@ -1,0 +1,2 @@
+> update
+> compile


### PR DESCRIPTION
Adding the `TokenSource` also gives more flexibility for alternative property names/environment variables/etc.

Might be worth having the same values for the remote cache plugin, and have someone configure non-default values